### PR TITLE
a very typical reason of unresponsive card is wrong insertion direction

### DIFF
--- a/pcsc_scan.c
+++ b/pcsc_scan.c
@@ -813,7 +813,7 @@ get_readers:
 
 			if (rgReaderStates_t[current_reader].dwEventState &
 				SCARD_STATE_MUTE)
-				printf("Unresponsive card, ");
+				printf("Unresponsive card (verify if it was inserted in the right direction), ");
 
 			printf("%s\n", color_end);
 


### PR DESCRIPTION
I finally found out that I had  an error similar to https://github.com/LudovicRousseau/pcsc-tools/issues/33 happened, it happened with a new card reader where there insertion direction was counter-intuitive, and I lost quite some time checking if the drivers were correct, if my e-card itself was broken, etc, etc.