### PR TITLE
Fix Hungarian eID URL

### DIFF
--- a/smartcard_list.txt
+++ b/smartcard_list.txt
@@ -5720,7 +5720,7 @@
 
 3B 87 80 01 80 31 B9 73 84 21 60 B8
 	Hungarian eID (2016) (eID)
-	http://kekkh.gov.hu/Eszemelyi/
+	https://eszemelyi.hu/en/
 
 3B 87 80 01 80 31 C0 73 D6 20 C0 32
 	RFID GeldKarte (girogo)

--- a/smartcard_list.txt
+++ b/smartcard_list.txt
@@ -6311,6 +6311,8 @@
 
 3B 8B 80 01 00 31 C0 64 08 44 03 76 00 90 00 36
 	American Express Blue Card (Germany) (Bank)
+	Mastercard issued by OTP Bank (Hungary) (Bank)
+	https://www.otpbank.hu/portal/en/Retail/Bankcards
 
 3B 8B 80 01 00 31 C0 64 08 44 03 93 00 90 00 D3
 	Novacard pp0815-04/20 chip (Bank)


### PR DESCRIPTION
KEKKH as a gov't agency ceased to exist five or so years ago.
eID is now run by NISZ.