### PR TITLE
Updated Finnish-related info in smartcard_list.txt to make it up to date

### DIFF
--- a/smartcard_list.txt
+++ b/smartcard_list.txt
@@ -4723,7 +4723,8 @@
 	https://github.com/OpenSC/OpenSC/wiki/Finnish-FINEID
 
 3B 7B 94 00 00 80 62 1[12] 51 56 46 69 6E 45 49 44
-	Finnish Electronic ID card (fineid card www.fineid.fi)
+	Finnish Electronic ID card for persons (Former FINeID card)
+	https://dvv.fi/en/citizen-certificate-and-electronic-identity
 
 3B 7B 94 00 00 80 65 52 16 07 86 53 83 00 90 00
 	Truemove H Thailand (Telecommunication)

--- a/smartcard_list.txt
+++ b/smartcard_list.txt
@@ -4720,7 +4720,7 @@
 3B 7B 18 00 00 80 62 01 54 56 46 69 6E 45 49 44
 	FineID identity card for organizations
 	http://fineid.fi/default.aspx?id=491
-	http://www.opensc-project.org/opensc/wiki/FinnishEid
+	https://github.com/OpenSC/OpenSC/wiki/Finnish-FINEID
 
 3B 7B 94 00 00 80 62 1[12] 51 56 46 69 6E 45 49 44
 	Finnish Electronic ID card (fineid card www.fineid.fi)

--- a/smartcard_list.txt
+++ b/smartcard_list.txt
@@ -4719,7 +4719,7 @@
 
 3B 7B 18 00 00 80 62 01 54 56 46 69 6E 45 49 44
 	FineID identity card for organizations
-	http://fineid.fi/default.aspx?id=491
+	https://dvv.fi/en/organisation-cards
 	https://github.com/OpenSC/OpenSC/wiki/Finnish-FINEID
 
 3B 7B 94 00 00 80 62 1[12] 51 56 46 69 6E 45 49 44


### PR DESCRIPTION
Used today _pcsc_scan_ today with my card, and noted on the way text info is not up to date.

Further look into _smartcard_list.txt_ both entries for organization and personal Finnish ID cards became obsolete.

Also OpenSC wiki link became obsolete. Found new [wiki](https://github.com/OpenSC/OpenSC/wiki) at [Github of OpenSC project](https://github.com/OpenSC/OpenSC/)

Hence necessary updates were made, verifying against past/historical content on archive.org. No hex data touched.