### PR TITLE
fix ATR parser path detect

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,10 @@ AC_ARG_ENABLE(ATRparser,
 if test "$ATRparser" != no
 then
 	AC_DEFINE_UNQUOTED(ATR_PARSER, "$ATRparser", [ATR parser to use])
+elif test "$ATR_PARSER" != no
+then
+	AC_DEFINE_UNQUOTED(ATR_PARSER, "$ATR_PARSER", [ATR parser to use])
+	ATRparser="$ATR_PARSER"
 fi
 
 dnl Checks for header files.


### PR DESCRIPTION
In https://github.com/LudovicRousseau/pcsc-tools/commit/57f1b8b9fd41f67b6309707096049bc894185235, LudovicRousseau try to add a option to specify ATR parser command. But in logic of this commit, if no --enable-parser=foobar was specified (i.e. $ATRparser == no), configure.ac will ignore default path which was set in $ATR_PARSER and then lead ATR analyze feature of pcsc_scan to be lost. So I add a new branch: if $ATRparser is no and $ATR_PARSER is not no, it will use $ATR_PARSER. At same time, set ATRparser to ATR_PARSER to ensure stats at the end works correctly.